### PR TITLE
feature: updated to dynamic shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A comprehensive quantum computing framework with modular implementations, built for researchers, educators, and quantum application developers.
 
-[![Python Version](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/downloads/)
-[![PyPI version](https://img.shields.io/pypi/v/qpiai-quantum.svg)](https://pypi.org/project/qpiai-quantum/)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/qpiai-quantum)](https://pypi.org/project/qpiai-quantum/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/qpiai-quantum)](https://pypi.org/project/qpiai-quantum/)
+[![License](https://img.shields.io/pypi/l/qpiai-quantum)](LICENSE)
 
 ## Architecture
 


### PR DESCRIPTION
Updated README badges to use dynamic PyPI shields.

- `PyPI version` — fetches the latest version automatically from PyPI
- `Python Versions` — shows supported versions from the package metadata (previously hardcoded as 3.8+)
- `License` — fetches from PyPI metadata instead of hardcoding

This keeps the badges accurate without manual updates.

<img width="468" height="50" alt="image" src="https://github.com/user-attachments/assets/51587443-e9e4-404e-87d2-d0a820d6b059" />
