### PR TITLE
fix(http): add request timeouts

### DIFF
--- a/qpiai_quantum/adapters/quantum_app_adapter.py
+++ b/qpiai_quantum/adapters/quantum_app_adapter.py
@@ -1,6 +1,6 @@
 from qpiai_quantum.authentication.user import get_user
 from qpiai_quantum.jobmanager.backend import Backend, ResolvedBackend
-from qpiai_quantum.config import get_server_url
+from qpiai_quantum.config import HTTP_TIMEOUT, get_server_url
 import requests
 
 
@@ -36,6 +36,7 @@ class QuantumAppAdapter:
         response = requests.get(
             f"{self.API_URL}/api/compute-resources/sdk/resolve/{backend.value}",
             headers=self.headers,
+            timeout=HTTP_TIMEOUT,
         )
         if response.status_code != 200:
             raise ValueError(f"Failed to resolve backend: {response.text}")

--- a/qpiai_quantum/authentication/auth.py
+++ b/qpiai_quantum/authentication/auth.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import os
 import requests
-from ..config import get_api_url
+from ..config import HTTP_TIMEOUT, get_api_url
 from .exceptions import (
     AuthError,
     APIKeyInvalidError,
@@ -74,7 +74,7 @@ class QpiAIQuantumAuth:
 
             headers = {"X-Secret-Token": current_api_key}
             url = get_api_url("/api/users/me")
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
 
             if response.status_code == 401:
                 raise APIKeyInvalidError("API key is invalid or expired")

--- a/qpiai_quantum/config.py
+++ b/qpiai_quantum/config.py
@@ -26,6 +26,9 @@ except ImportError:
 # Default server URL
 DEFAULT_SERVER_URL = "https://qcloud-server.qpiai.tech"
 
+# Bound both connection establishment and server response time for cloud requests.
+HTTP_TIMEOUT = (10, 120)
+
 
 def get_server_url() -> str:
     """

--- a/qpiai_quantum/jobmanager/jobmanager.py
+++ b/qpiai_quantum/jobmanager/jobmanager.py
@@ -10,7 +10,7 @@ import numpy as np  # type: ignore
 
 from ..authentication.user import get_user
 from ..circuit.circuit import Circuit
-from ..config import get_api_url, get_sse_url
+from ..config import HTTP_TIMEOUT, get_api_url, get_sse_url
 from ..icr.icr import IntermediateCircuitRepresentation
 from .exceptions import (
     AuthenticationError,
@@ -113,7 +113,7 @@ class JobManager:
             # Fetch compute resources from API
             url = get_api_url("/api/compute-resources")
             headers = self._get_auth_header()
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
 
             if response.status_code == 200:
                 resources = response.json()
@@ -165,7 +165,7 @@ class JobManager:
         try:
             url = get_api_url("/api/compute-resources")
             headers = self._get_auth_header()
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
             response.raise_for_status()
 
             resources = response.json()
@@ -203,7 +203,7 @@ class JobManager:
         try:
             url = get_api_url(f"/api/experiments/by-name?name={experiment_name}")
             headers = self._get_auth_header()
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
 
             if response.status_code == 404:
                 raise ExperimentNotFoundError(experiment_name)
@@ -351,7 +351,7 @@ class JobManager:
             logger.debug(f"Creating circuit with payload: {circuit_payload}")
 
             circuit_response = requests.post(
-                circuit_url, json=circuit_payload, headers=headers
+                circuit_url, json=circuit_payload, headers=headers, timeout=HTTP_TIMEOUT
             )
 
             if circuit_response.status_code == 409:
@@ -370,7 +370,9 @@ class JobManager:
                     if experiment_id:
                         list_url += f"&experiment_id={experiment_id}"
 
-                    list_response = requests.get(list_url, headers=headers)
+                    list_response = requests.get(
+                        list_url, headers=headers, timeout=HTTP_TIMEOUT
+                    )
                     list_response.raise_for_status()
 
                     circuits_data = list_response.json()
@@ -399,7 +401,10 @@ class JobManager:
                             "need_density_matrix": need_density_matrix,
                         }
                         circuit_update_response = requests.put(
-                            update_url, json=update_payload, headers=headers
+                            update_url,
+                            json=update_payload,
+                            headers=headers,
+                            timeout=HTTP_TIMEOUT,
                         )
                         circuit_update_response.raise_for_status()
                     else:
@@ -425,7 +430,9 @@ class JobManager:
             if compute_resource_id is not None:
                 job_payload["compute_resource_id"] = compute_resource_id
 
-            job_response = requests.post(job_url, json=job_payload, headers=headers)
+            job_response = requests.post(
+                job_url, json=job_payload, headers=headers, timeout=HTTP_TIMEOUT
+            )
 
             # Enhanced error handling for 400 Bad Request
             if job_response.status_code == 400:
@@ -580,7 +587,9 @@ class JobManager:
 
             url = get_api_url(f"/api/jobs/{job_id}")
             headers = self._get_auth_header()
-            response = requests.get(url, headers=headers, stream=True)
+            response = requests.get(
+                url, headers=headers, stream=True, timeout=HTTP_TIMEOUT
+            )
             if response.status_code == 404:
                 logger.info(f"Job {job_id} not found")
                 return None
@@ -629,7 +638,7 @@ class JobManager:
             # Query for currently running jobs
             url = get_api_url("/api/jobs/user?status=running&page_size=1")
             headers = self._get_auth_header()
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
             response.raise_for_status()
 
             data = response.json()
@@ -729,7 +738,7 @@ class JobManager:
             url = get_api_url(f"/api/jobs/user?{query_string}")
 
             headers = self._get_auth_header()
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
             response.raise_for_status()
 
             data = response.json()
@@ -807,7 +816,7 @@ class JobManager:
             # Send cancellation request
             url = get_api_url(f"/api/jobs/{job_id}/cancel")
             headers = self._get_auth_header()
-            response = requests.post(url, headers=headers)
+            response = requests.post(url, headers=headers, timeout=HTTP_TIMEOUT)
 
             if response.status_code == 404:
                 raise JobManagerError(f"Job {job_id} not found")
@@ -887,7 +896,7 @@ class JobManager:
             # Send deletion request
             url = get_api_url(f"/api/jobs/{job_id}")
             headers = self._get_auth_header()
-            response = requests.delete(url, headers=headers)
+            response = requests.delete(url, headers=headers, timeout=HTTP_TIMEOUT)
 
             if response.status_code == 404:
                 raise JobManagerError(f"Job {job_id} not found")
@@ -997,7 +1006,7 @@ class JobManager:
             # Get job details (includes results if completed)
             url = get_api_url(f"/api/jobs/{job_id}")
             headers = self._get_auth_header()
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
             response.raise_for_status()
             job_data = response.json()
 
@@ -1142,6 +1151,7 @@ class JobManager:
                 download_url,
                 json={"s3_path": s3_path},
                 headers=headers,
+                timeout=HTTP_TIMEOUT,
             )
             response.raise_for_status()
             presigned_data = response.json()
@@ -1161,7 +1171,7 @@ class JobManager:
             )
 
         try:
-            file_response = requests.get(presigned_url)
+            file_response = requests.get(presigned_url, timeout=HTTP_TIMEOUT)
             file_response.raise_for_status()
         except requests.exceptions.RequestException as e:
             raise JobManagerError(

--- a/tests/test_http_timeouts.py
+++ b/tests/test_http_timeouts.py
@@ -1,0 +1,24 @@
+import ast
+from pathlib import Path
+
+from qpiai_quantum.config import HTTP_TIMEOUT
+
+
+def test_http_timeout_has_bounded_connect_and_read_values():
+    assert HTTP_TIMEOUT == (10, 120)
+
+
+def test_all_requests_calls_specify_a_timeout():
+    package_dir = Path(__file__).parents[1] / "qpiai_quantum"
+
+    for source_file in package_dir.rglob("*.py"):
+        tree = ast.parse(source_file.read_text())
+        for call in ast.walk(tree):
+            if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Attribute):
+                continue
+            if not isinstance(call.func.value, ast.Name) or call.func.value.id != "requests":
+                continue
+            assert any(keyword.arg == "timeout" for keyword in call.keywords), (
+                f"{source_file.relative_to(package_dir.parent)}:{call.lineno} "
+                "is missing a request timeout"
+            )


### PR DESCRIPTION
## Summary
- define a shared `(10, 120)` connect/read timeout
- apply it to all direct SDK `requests` calls, including presigned result downloads
- add a regression test for unbounded request calls

## Validation
- direct timeout regression assertions passed in `.venv`
- `git diff --check` passed

Closes #11