### PR TITLE
fix: specify utf-8 encoding when reading source files in test

### DIFF
--- a/tests/test_http_timeouts.py
+++ b/tests/test_http_timeouts.py
@@ -12,7 +12,7 @@ def test_all_requests_calls_specify_a_timeout():
     package_dir = Path(__file__).parents[1] / "qpiai_quantum"
 
     for source_file in package_dir.rglob("*.py"):
-        tree = ast.parse(source_file.read_text())
+        tree = ast.parse(source_file.read_text(encoding="utf-8"))
         for call in ast.walk(tree):
             if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Attribute):
                 continue


### PR DESCRIPTION
## Changes

Fixed `UnicodeDecodeError` on Windows when running `test_http_timeouts.py`.
`Path.read_text()` defaults to the system locale encoding (cp1252 on Windows),
which fails for Python source files containing UTF-8 characters. Added
`encoding="utf-8"` to the `.read_text()` call.

## Files Changed
- `tests/test_http_timeouts.py` — 1 line change