### PR TITLE
fix: Circuit.depth() returns 0 for measure-only/barrier-only circuits

### DIFF
--- a/qpiai_quantum/circuit/circuit.py
+++ b/qpiai_quantum/circuit/circuit.py
@@ -1104,6 +1104,7 @@ class Circuit:
             return 0
 
         qubit_depths = [0] * self.icr.num_qubits
+        actual_qubit = 0
         for operation in self.icr.evolve:
             if operation.operation_type == OperationType.BARRIER:
                 continue

--- a/tests/test_circuit_operations.py
+++ b/tests/test_circuit_operations.py
@@ -340,6 +340,25 @@ def test_circuit_depth():
     assert circ.depth() == 3
 
 
+def test_circuit_depth_measure_only():
+    circ = Circuit(2, 2)
+    circ.measure(0, 0)
+    circ.measure(1, 1)
+    assert circ.depth() == 0
+
+
+def test_circuit_depth_barrier_only():
+    circ = Circuit(3)
+    circ.barrier(0, 1)
+    circ.barrier(1, 2)
+    assert circ.depth() == 0
+
+
+def test_circuit_depth_empty():
+    circ = Circuit(3)
+    assert circ.depth() == 0
+
+
 def test_circuit_to_json():
     circ = Circuit(2)
     circ.h(0)


### PR DESCRIPTION
## Summary

Fixes #22 where Circuit.depth() raises UnboundLocalError when the circuit contains only measurement and/or barrier operations (no gates).

## Root Cause

The variable actual_qubit was only assigned inside the for-loop body that processes gates. When every operation was a barrier or measurement, all iterations hit continue, leaving the variable unbound at the return statement.

## Fix

Initialize actual_qubit = 0 before the loop so it always has a value, even when no gate operations exist.

## Tests Added

- test_circuit_depth_measure_only — Circuit with only measurements → depth() = 0
- test_circuit_depth_barrier_only — Circuit with only barriers → depth() = 0
- test_circuit_depth_empty — Circuit with no operations → depth() = 0

## Verification

- 4 depth tests pass (1 existing + 3 new)
- Full test suite: 239 passed, 28 skipped, 0 failed
