### PR TITLE
Fix GroverSearch README example: replace invalid oracle_type with target

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ print(f"Measurement results: {counts}")
 from qpiai_quantum import GroverSearch, QFT, ShorsAlgorithm
 
 # Grover's search
-grover = GroverSearch(num_qubits=3, oracle_type="custom")
+grover = GroverSearch(num_qubits=3, target="101")
+circuit = grover.build_circuit()
 
 # Quantum Fourier Transform
 qft = QFT(num_qubits=4)


### PR DESCRIPTION
---

## Problem

The "Quantum Algorithms" example in the Quick Start section of README.md uses:

```python
grover = GroverSearch(num_qubits=3, oracle_type="custom")
```

Running this exact snippet raises:

```
TypeError: GroverSearch.__init__() got an unexpected keyword argument 'oracle_type'
```

## Root Cause

`GroverSearch`'s actual constructor signature is:

```python
GroverSearch(num_qubits: int, target: str | None = None)
```

`oracle_type` is a valid parameter elsewhere in the SDK — but only on `DeutschJozsa` (see `qpiai_quantum/algorithms/deutsch_jozsa.py`), which supports multiple named oracle variants (`"constant_zero"`, `"constant_one"`, `"balanced"`) and branches on that string internally.

`GroverSearch` does have an oracle (`_oracle()`), but it's a single, fixed construction driven by the `target` bitstring — there's no selectable "type" for it to branch on. It looks like the Grover's search example was likely adapted from the Deutsch-Jozsa example and the parameter name was never updated to match `GroverSearch`'s real API.

## Fix

Updated the example to use the real `target` parameter, and added a `build_circuit()` call so the snippet demonstrates actual working usage:

```python
grover = GroverSearch(num_qubits=3, target="101")
circuit = grover.build_circuit()
```

## Testing

Verified the corrected snippet runs without error:

```python
from qpiai_quantum import GroverSearch

grover = GroverSearch(num_qubits=3, target="101")
circuit = grover.build_circuit()
```
